### PR TITLE
Fix deprecated api urls

### DIFF
--- a/resources/service.go
+++ b/resources/service.go
@@ -20,7 +20,7 @@ func NewService(r gcore.Requester) *Service {
 
 func (s *Service) Create(ctx context.Context, req *CreateRequest) (*Resource, error) {
 	var resource Resource
-	if err := s.r.Request(ctx, http.MethodPost, "/resources", req, &resource); err != nil {
+	if err := s.r.Request(ctx, http.MethodPost, "/cdn/resources", req, &resource); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
 
@@ -29,7 +29,7 @@ func (s *Service) Create(ctx context.Context, req *CreateRequest) (*Resource, er
 
 func (s *Service) Get(ctx context.Context, id int64) (*Resource, error) {
 	var resource Resource
-	if err := s.r.Request(ctx, http.MethodGet, fmt.Sprintf("/resources/%d", id), nil, &resource); err != nil {
+	if err := s.r.Request(ctx, http.MethodGet, fmt.Sprintf("/cdn/resources/%d", id), nil, &resource); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
 
@@ -38,7 +38,7 @@ func (s *Service) Get(ctx context.Context, id int64) (*Resource, error) {
 
 func (s *Service) Update(ctx context.Context, id int64, req *UpdateRequest) (*Resource, error) {
 	var resource Resource
-	if err := s.r.Request(ctx, http.MethodPut, fmt.Sprintf("/resources/%d", id), req, &resource); err != nil {
+	if err := s.r.Request(ctx, http.MethodPut, fmt.Sprintf("/cdn/resources/%d", id), req, &resource); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
 

--- a/rules/service.go
+++ b/rules/service.go
@@ -21,7 +21,7 @@ func NewService(r gcore.Requester) *Service {
 func (s *Service) Create(ctx context.Context, resourceID int64, req *CreateRequest) (*Rule, error) {
 	var rule Rule
 
-	path := fmt.Sprintf("/resources/%d/rules", resourceID)
+	path := fmt.Sprintf("/cdn/resources/%d/rules", resourceID)
 	if err := s.r.Request(ctx, http.MethodPost, path, req, &rule); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
@@ -32,7 +32,7 @@ func (s *Service) Create(ctx context.Context, resourceID int64, req *CreateReque
 func (s *Service) Get(ctx context.Context, resourceID, ruleID int64) (*Rule, error) {
 	var rule Rule
 
-	path := fmt.Sprintf("/resources/%d/rules/%d", resourceID, ruleID)
+	path := fmt.Sprintf("/cdn/resources/%d/rules/%d", resourceID, ruleID)
 	if err := s.r.Request(ctx, http.MethodGet, path, nil, &rule); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
@@ -43,7 +43,7 @@ func (s *Service) Get(ctx context.Context, resourceID, ruleID int64) (*Rule, err
 func (s *Service) Update(ctx context.Context, resourceID, ruleID int64, req *UpdateRequest) (*Rule, error) {
 	var rule Rule
 
-	path := fmt.Sprintf("/resources/%d/rules/%d", resourceID, ruleID)
+	path := fmt.Sprintf("/cdn/resources/%d/rules/%d", resourceID, ruleID)
 	if err := s.r.Request(ctx, http.MethodPut, path, req, &rule); err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
@@ -52,7 +52,7 @@ func (s *Service) Update(ctx context.Context, resourceID, ruleID int64, req *Upd
 }
 
 func (s *Service) Delete(ctx context.Context, resourceID, ruleID int64) error {
-	path := fmt.Sprintf("/resources/%d/rules/%d", resourceID, ruleID)
+	path := fmt.Sprintf("/cdn/resources/%d/rules/%d", resourceID, ruleID)
 	if err := s.r.Request(ctx, http.MethodDelete, path, nil, nil); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}


### PR DESCRIPTION
Urls in code was deprecated and now is disabled. So terraform provider is broken now.
This pull request fix api urls.