### PR TITLE
CDN-6181 add missing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE and editors
+.idea
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/gcore/options.go
+++ b/gcore/options.go
@@ -1,26 +1,42 @@
 package gcore
 
 type Options struct {
-	EdgeCacheSettings    *EdgeCacheSettings    `json:"edge_cache_settings"`
 	BrowserCacheSettings *BrowserCacheSettings `json:"browser_cache_settings"`
+	CacheHttpHeaders     *CacheHttpHeaders     `json:"cache_http_headers"` // deprecated in favor of response_headers_hiding_policy
+	Cors                 *Cors                 `json:"cors"`
+	EdgeCacheSettings    *EdgeCacheSettings    `json:"edge_cache_settings"`
+	ForceReturn          *ForceReturn          `json:"force_return"`
+	GzipOn               *GzipOn               `json:"gzipOn"`
 	HostHeader           *HostHeader           `json:"hostHeader"`
-	Webp                 *Webp                 `json:"webp"` // deprecated option
-	Rewrite              *Rewrite              `json:"rewrite"`
+	IgnoreQueryString    *IgnoreQueryString    `json:"ignoreQueryString"`
+	QueryParamsBlacklist *QueryParamsBlacklist `json:"query_params_blacklist"`
+	QueryParamsWhitelist *QueryParamsWhitelist `json:"query_params_whitelist"`
 	RedirectHttpToHttps  *RedirectHttpToHttps  `json:"redirect_http_to_https"`
 	RequestLimiter       *RequestLimiter       `json:"request_limiter"`
-	GzipOn               *GzipOn               `json:"gzipOn"`
-	Cors                 *Cors                 `json:"cors"`
+	Rewrite              *Rewrite              `json:"rewrite"`
 	SNI                  *SNIOption            `json:"sni"`
-	IgnoreQueryString    *IgnoreQueryString    `json:"ignoreQueryString"`
-	QueryParamsWhitelist *QueryParamsWhitelist `json:"query_params_whitelist"`
-	QueryParamsBlacklist *QueryParamsBlacklist `json:"query_params_blacklist"`
+	StaticHeaders        *StaticHeaders        `json:"staticHeaders"` // deprecated in favor of static_response_headers
 	StaticRequestHeaders *StaticRequestHeaders `json:"staticRequestHeaders"`
-	StaticHeaders        *StaticHeaders        `json:"staticHeaders"`      // deprecated in favor of static_response_headers
-	CacheHttpHeaders     *CacheHttpHeaders     `json:"cache_http_headers"` // deprecated in favor of response_headers_hiding_policy
-	WebSockets           *WebSockets           `json:"websockets"`
 	TLSVersions          *TLSVersions          `json:"tls_versions"`
 	UseRSALECert         *UseRSALECert         `json:"use_rsa_le_cert"`
-	ForceReturn          *ForceReturn          `json:"force_return"`
+	Webp                 *Webp                 `json:"webp"` // deprecated option
+	WebSockets           *WebSockets           `json:"websockets"`
+}
+
+type BrowserCacheSettings struct {
+	Enabled bool   `json:"enabled"`
+	Value   string `json:"value"`
+}
+
+// deprecated in favor of response_headers_hiding_policy
+type CacheHttpHeaders struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
+}
+
+type Cors struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
 }
 
 type EdgeCacheSettings struct {
@@ -30,27 +46,35 @@ type EdgeCacheSettings struct {
 	Default      string            `json:"default"`
 }
 
+type ForceReturn struct {
+	Enabled bool   `json:"enabled"`
+	Code    int    `json:"code"`
+	Body    string `json:"body"`
+}
+
+type GzipOn struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
 type HostHeader struct {
 	Enabled bool   `json:"enabled"`
 	Value   string `json:"value"`
 }
 
-type BrowserCacheSettings struct {
-	Enabled bool   `json:"enabled"`
-	Value   string `json:"value"`
+type IgnoreQueryString struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
 }
 
-type Webp struct {
-	Enabled     bool `json:"enabled"`
-	JPGQuality  int  `json:"jpg_quality"`
-	PNGQuality  int  `json:"png_quality"`
-	PNGLossless bool `json:"png_lossless"`
+type QueryParamsBlacklist struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
 }
 
-type Rewrite struct {
-	Enabled bool   `json:"enabled"`
-	Body    string `json:"body"`
-	Flag    string `json:"flag"`
+type QueryParamsWhitelist struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
 }
 
 type RedirectHttpToHttps struct {
@@ -66,14 +90,10 @@ type RequestLimiter struct {
 	Delay    int    `json:"delay"`
 }
 
-type GzipOn struct {
-	Enabled bool `json:"enabled"`
-	Value   bool `json:"value"`
-}
-
-type Cors struct {
-	Enabled bool     `json:"enabled"`
-	Value   []string `json:"value"`
+type Rewrite struct {
+	Enabled bool   `json:"enabled"`
+	Body    string `json:"body"`
+	Flag    string `json:"flag"`
 }
 
 type SNIOption struct {
@@ -82,39 +102,15 @@ type SNIOption struct {
 	CustomHostname string `json:"custom_hostname"`
 }
 
-type IgnoreQueryString struct {
-	Enabled bool `json:"enabled"`
-	Value   bool `json:"value"`
-}
-
-type QueryParamsWhitelist struct {
-	Enabled bool     `json:"enabled"`
-	Value   []string `json:"value"`
-}
-
-type QueryParamsBlacklist struct {
-	Enabled bool     `json:"enabled"`
-	Value   []string `json:"value"`
-}
-
-type StaticRequestHeaders struct {
-	Enabled bool              `json:"enabled"`
-	Value   map[string]string `json:"value"`
-}
-
+// deprecated in favor of static_response_headers
 type StaticHeaders struct {
 	Enabled bool              `json:"enabled"`
 	Value   map[string]string `json:"value"`
 }
 
-type CacheHttpHeaders struct {
-	Enabled bool     `json:"enabled"`
-	Value   []string `json:"value"`
-}
-
-type WebSockets struct {
-	Enabled bool `json:"enabled"`
-	Value   bool `json:"value"`
+type StaticRequestHeaders struct {
+	Enabled bool              `json:"enabled"`
+	Value   map[string]string `json:"value"`
 }
 
 type TLSVersions struct {
@@ -127,8 +123,15 @@ type UseRSALECert struct {
 	Value   bool `json:"value"`
 }
 
-type ForceReturn struct {
-	Enabled bool   `json:"enabled"`
-	Code    int    `json:"code"`
-	Body    string `json:"body"`
+// deprecated option
+type Webp struct {
+	Enabled     bool `json:"enabled"`
+	JPGQuality  int  `json:"jpg_quality"`
+	PNGQuality  int  `json:"png_quality"`
+	PNGLossless bool `json:"png_lossless"`
+}
+
+type WebSockets struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
 }

--- a/gcore/options.go
+++ b/gcore/options.go
@@ -4,7 +4,7 @@ type Options struct {
 	EdgeCacheSettings    *EdgeCacheSettings    `json:"edge_cache_settings"`
 	BrowserCacheSettings *BrowserCacheSettings `json:"browser_cache_settings"`
 	HostHeader           *HostHeader           `json:"hostHeader"`
-	Webp                 *Webp                 `json:"webp"`
+	Webp                 *Webp                 `json:"webp"` // deprecated option
 	Rewrite              *Rewrite              `json:"rewrite"`
 	RedirectHttpToHttps  *RedirectHttpToHttps  `json:"redirect_http_to_https"`
 	RequestLimiter       *RequestLimiter       `json:"request_limiter"`
@@ -15,8 +15,8 @@ type Options struct {
 	QueryParamsWhitelist *QueryParamsWhitelist `json:"query_params_whitelist"`
 	QueryParamsBlacklist *QueryParamsBlacklist `json:"query_params_blacklist"`
 	StaticRequestHeaders *StaticRequestHeaders `json:"staticRequestHeaders"`
-	StaticHeaders        *StaticHeaders        `json:"staticHeaders"`
-	CacheHttpHeaders     *CacheHttpHeaders     `json:"cache_http_headers"`
+	StaticHeaders        *StaticHeaders        `json:"staticHeaders"`      // deprecated in favor of static_response_headers
+	CacheHttpHeaders     *CacheHttpHeaders     `json:"cache_http_headers"` // deprecated in favor of response_headers_hiding_policy
 	WebSockets           *WebSockets           `json:"websockets"`
 	TLSVersions          *TLSVersions          `json:"tls_versions"`
 	UseRSALECert         *UseRSALECert         `json:"use_rsa_le_cert"`

--- a/gcore/options.go
+++ b/gcore/options.go
@@ -1,26 +1,59 @@
 package gcore
 
 type Options struct {
-	BrowserCacheSettings *BrowserCacheSettings `json:"browser_cache_settings"`
-	CacheHttpHeaders     *CacheHttpHeaders     `json:"cache_http_headers"` // deprecated in favor of response_headers_hiding_policy
-	Cors                 *Cors                 `json:"cors"`
-	EdgeCacheSettings    *EdgeCacheSettings    `json:"edge_cache_settings"`
-	ForceReturn          *ForceReturn          `json:"force_return"`
-	GzipOn               *GzipOn               `json:"gzipOn"`
-	HostHeader           *HostHeader           `json:"hostHeader"`
-	IgnoreQueryString    *IgnoreQueryString    `json:"ignoreQueryString"`
-	QueryParamsBlacklist *QueryParamsBlacklist `json:"query_params_blacklist"`
-	QueryParamsWhitelist *QueryParamsWhitelist `json:"query_params_whitelist"`
-	RedirectHttpToHttps  *RedirectHttpToHttps  `json:"redirect_http_to_https"`
-	RequestLimiter       *RequestLimiter       `json:"request_limiter"`
-	Rewrite              *Rewrite              `json:"rewrite"`
-	SNI                  *SNIOption            `json:"sni"`
-	StaticHeaders        *StaticHeaders        `json:"staticHeaders"` // deprecated in favor of static_response_headers
-	StaticRequestHeaders *StaticRequestHeaders `json:"staticRequestHeaders"`
-	TLSVersions          *TLSVersions          `json:"tls_versions"`
-	UseRSALECert         *UseRSALECert         `json:"use_rsa_le_cert"`
-	Webp                 *Webp                 `json:"webp"` // deprecated option
-	WebSockets           *WebSockets           `json:"websockets"`
+	AllowedHTTPMethods          *AllowedHTTPMethods          `json:"allowedHttpMethods"`
+	BrotliCompression           *BrotliCompression           `json:"brotli_compression"`
+	BrowserCacheSettings        *BrowserCacheSettings        `json:"browser_cache_settings"`
+	CacheHttpHeaders            *CacheHttpHeaders            `json:"cache_http_headers"` // deprecated in favor of response_headers_hiding_policy
+	Cors                        *Cors                        `json:"cors"`
+	CountryACL                  *CountryACL                  `json:"country_acl"`
+	DisableCache                *DisableCache                `json:"disable_cache"`
+	DisableProxyForceRanges     *DisableProxyForceRanges     `json:"disable_proxy_force_ranges"`
+	EdgeCacheSettings           *EdgeCacheSettings           `json:"edge_cache_settings"`
+	FetchCompressed             *FetchCompressed             `json:"fetch_compressed"`
+	FollowOriginRedirect        *FollowOriginRedirect        `json:"follow_origin_redirect"`
+	ForceReturn                 *ForceReturn                 `json:"force_return"`
+	ForwardHostHeader           *ForwardHostHeader           `json:"forward_host_header"`
+	GzipOn                      *GzipOn                      `json:"gzipOn"`
+	HostHeader                  *HostHeader                  `json:"hostHeader"`
+	HTTP3Enabled                *HTTP3Enabled                `json:"http3_enabled"`
+	IgnoreCookie                *IgnoreCookie                `json:"ignore_cookie"`
+	IgnoreQueryString           *IgnoreQueryString           `json:"ignoreQueryString"`
+	ImageStack                  *ImageStack                  `json:"image_stack"`
+	IPAddressACL                *IPAddressACL                `json:"ip_address_acl"`
+	LimitBandwidth              *LimitBandwidth              `json:"limit_bandwidth"`
+	ProxyCacheMethodsSet        *ProxyCacheMethodsSet        `json:"proxy_cache_methods_set"`
+	QueryParamsBlacklist        *QueryParamsBlacklist        `json:"query_params_blacklist"`
+	QueryParamsWhitelist        *QueryParamsWhitelist        `json:"query_params_whitelist"`
+	RedirectHttpsToHttp         *RedirectHttpsToHttp         `json:"redirect_https_to_http"`
+	RedirectHttpToHttps         *RedirectHttpToHttps         `json:"redirect_http_to_https"`
+	ReferrerACL                 *ReferrerACL                 `json:"referrer_acl"`
+	RequestLimiter              *RequestLimiter              `json:"request_limiter"`
+	ResponseHeadersHidingPolicy *ResponseHeadersHidingPolicy `json:"response_headers_hiding_policy"`
+	Rewrite                     *Rewrite                     `json:"rewrite"`
+	SecureKey                   *SecureKey                   `json:"secure_key"`
+	Slice                       *Slice                       `json:"slice"`
+	SNI                         *SNIOption                   `json:"sni"`
+	Stale                       *Stale                       `json:"stale"`
+	StaticHeaders               *StaticHeaders               `json:"staticHeaders"` // deprecated in favor of static_response_headers
+	StaticRequestHeaders        *StaticRequestHeaders        `json:"staticRequestHeaders"`
+	StaticResponseHeaders       *StaticResponseHeaders       `json:"static_response_headers"`
+	TLSVersions                 *TLSVersions                 `json:"tls_versions"`
+	UseDefaultLEChain           *UseDefaultLEChain           `json:"use_default_le_chain"`
+	UserAgentACL                *UserAgentACL                `json:"user_agent_acl"`
+	UseRSALECert                *UseRSALECert                `json:"use_rsa_le_cert"`
+	Webp                        *Webp                        `json:"webp"` // deprecated in favor of image_stack
+	WebSockets                  *WebSockets                  `json:"websockets"`
+}
+
+type AllowedHTTPMethods struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
+}
+
+type BrotliCompression struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
 }
 
 type BrowserCacheSettings struct {
@@ -28,7 +61,7 @@ type BrowserCacheSettings struct {
 	Value   string `json:"value"`
 }
 
-// deprecated in favor of response_headers_hiding_policy
+// deprecated in favor of ResponseHeadersHidingPolicy
 type CacheHttpHeaders struct {
 	Enabled bool     `json:"enabled"`
 	Value   []string `json:"value"`
@@ -39,6 +72,22 @@ type Cors struct {
 	Value   []string `json:"value"`
 }
 
+type CountryACL struct {
+	Enabled        bool     `json:"enabled"`
+	PolicyType     string   `json:"policy_type"`
+	ExceptedValues []string `json:"excepted_values"`
+}
+
+type DisableCache struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
+type DisableProxyForceRanges struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
 type EdgeCacheSettings struct {
 	Enabled      bool              `json:"enabled"`
 	Value        string            `json:"value"`
@@ -46,10 +95,25 @@ type EdgeCacheSettings struct {
 	Default      string            `json:"default"`
 }
 
+type FetchCompressed struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
+type FollowOriginRedirect struct {
+	Enabled bool  `json:"enabled"`
+	Codes   []int `json:"codes"`
+}
+
 type ForceReturn struct {
 	Enabled bool   `json:"enabled"`
 	Code    int    `json:"code"`
 	Body    string `json:"body"`
+}
+
+type ForwardHostHeader struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
 }
 
 type GzipOn struct {
@@ -62,7 +126,43 @@ type HostHeader struct {
 	Value   string `json:"value"`
 }
 
+type HTTP3Enabled struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
+type IgnoreCookie struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
 type IgnoreQueryString struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
+type ImageStack struct {
+	Enabled     bool `json:"enabled"`
+	AvifEnabled bool `json:"avif_enabled"`
+	WebpEnabled bool `json:"webp_enabled"`
+	Quality     int  `json:"quality"`
+	PngLossless bool `json:"png_lossless"`
+}
+
+type IPAddressACL struct {
+	Enabled        bool     `json:"enabled"`
+	PolicyType     string   `json:"policy_type"`
+	ExceptedValues []string `json:"excepted_values"`
+}
+
+type LimitBandwidth struct {
+	Enabled   bool   `json:"enabled"`
+	LimitType string `json:"limit_type"`
+	Speed     int    `json:"speed"`
+	Buffer    int    `json:"buffer"`
+}
+
+type ProxyCacheMethodsSet struct {
 	Enabled bool `json:"enabled"`
 	Value   bool `json:"value"`
 }
@@ -77,9 +177,20 @@ type QueryParamsWhitelist struct {
 	Value   []string `json:"value"`
 }
 
+type RedirectHttpsToHttp struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
 type RedirectHttpToHttps struct {
 	Enabled bool `json:"enabled"`
 	Value   bool `json:"value"`
+}
+
+type ReferrerACL struct {
+	Enabled        bool     `json:"enabled"`
+	PolicyType     string   `json:"policy_type"`
+	ExceptedValues []string `json:"excepted_values"`
 }
 
 type RequestLimiter struct {
@@ -90,10 +201,27 @@ type RequestLimiter struct {
 	Delay    int    `json:"delay"`
 }
 
+type ResponseHeadersHidingPolicy struct {
+	Enabled  bool     `json:"enabled"`
+	Mode     string   `json:"mode"`
+	Excepted []string `json:"excepted"`
+}
+
 type Rewrite struct {
 	Enabled bool   `json:"enabled"`
 	Body    string `json:"body"`
 	Flag    string `json:"flag"`
+}
+
+type SecureKey struct {
+	Enabled bool   `json:"enabled"`
+	Key     string `json:"key"`
+	Type    int    `json:"type"`
+}
+
+type Slice struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
 }
 
 type SNIOption struct {
@@ -102,7 +230,12 @@ type SNIOption struct {
 	CustomHostname string `json:"custom_hostname"`
 }
 
-// deprecated in favor of static_response_headers
+type Stale struct {
+	Enabled bool     `json:"enabled"`
+	Value   []string `json:"value"`
+}
+
+// deprecated in favor of StaticResponseHeaders
 type StaticHeaders struct {
 	Enabled bool              `json:"enabled"`
 	Value   map[string]string `json:"value"`
@@ -113,9 +246,31 @@ type StaticRequestHeaders struct {
 	Value   map[string]string `json:"value"`
 }
 
+type StaticResponseHeadersItem struct {
+	Name   string   `json:"name"`
+	Value  []string `json:"value"`
+	Always bool     `json:"always"`
+}
+
+type StaticResponseHeaders struct {
+	Enabled bool                        `json:"enabled"`
+	Value   []StaticResponseHeadersItem `json:"value"`
+}
+
 type TLSVersions struct {
 	Enabled bool     `json:"enabled"`
 	Value   []string `json:"value"`
+}
+
+type UseDefaultLEChain struct {
+	Enabled bool `json:"enabled"`
+	Value   bool `json:"value"`
+}
+
+type UserAgentACL struct {
+	Enabled        bool     `json:"enabled"`
+	PolicyType     string   `json:"policy_type"`
+	ExceptedValues []string `json:"excepted_values"`
 }
 
 type UseRSALECert struct {
@@ -123,7 +278,7 @@ type UseRSALECert struct {
 	Value   bool `json:"value"`
 }
 
-// deprecated option
+// deprecated in favor of ImageStack
 type Webp struct {
 	Enabled     bool `json:"enabled"`
 	JPGQuality  int  `json:"jpg_quality"`


### PR DESCRIPTION
Sorted options struct fields

Sorted options structs

Added missing options according to https://apidocs.gcore.com/docs/cdn

- AllowedHTTPMethods
- BrotliCompression
- CountryACL
- DisableCache
- DisableProxyForceRanges
- FetchCompressed
- FollowOriginRedirect
- ForwardHostHeader
- HTTP3Enabled
- IgnoreCookie
- ImageStack
- IPAddressACL
- LimitBandwidth
- ProxyCacheMethodsSet
- RedirectHttpsToHttp
- ReferrerACL
- ResponseHeadersHidingPolicy
- SecureKey
- Slice
- Stale
- StaticResponseHeaders
- UseDefaultLEChain
- UserAgentACL