### PR TITLE
fix origin groups scheme: using a proper use_next field in json

### DIFF
--- a/origingroups/origingroups.go
+++ b/origingroups/origingroups.go
@@ -13,7 +13,7 @@ type OriginGroupService interface {
 
 type GroupRequest struct {
 	Name    string          `json:"name"`
-	UseNext bool            `json:"useNext"`
+	UseNext bool            `json:"use_next"`
 	Sources []SourceRequest `json:"sources"`
 }
 
@@ -26,7 +26,7 @@ type SourceRequest struct {
 type OriginGroup struct {
 	ID      int64    `json:"id"`
 	Name    string   `json:"name"`
-	UseNext bool     `json:"useNext"`
+	UseNext bool     `json:"use_next"`
 	Sources []Source `json:"sources"`
 }
 


### PR DESCRIPTION
- fix origin groups json schema
- rename deprecated `useNext` to a proper `use_next` field, so it can be properly specified in the requests to the backend