### PR TITLE
CDP-617 support 2-step deletion for rules and resources

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -53,6 +53,10 @@ type UpdateRequest struct {
 	Options            *gcore.Options `json:"options,omitempty"`
 }
 
+type ActivateRequest struct {
+	Active bool `json:"active"`
+}
+
 type Resource struct {
 	ID                 int64          `json:"id"`
 	Name               string         `json:"name"`

--- a/resources/service.go
+++ b/resources/service.go
@@ -48,13 +48,13 @@ func (s *Service) Update(ctx context.Context, id int64, req *UpdateRequest) (*Re
 func (s *Service) Delete(ctx context.Context, resourceID int64) error {
 	path := fmt.Sprintf("/cdn/resources/%d", resourceID)
 
-	var deactivateRequestBody ActivateRequest = ActivateRequest{
+	var body ActivateRequest = ActivateRequest{
 		Active: false,
 	}
 	var resource Resource
 
 	// deactivate the resource instance before deletion
-	if err := s.r.Request(ctx, http.MethodPatch, path, &deactivateRequestBody, &resource); err != nil {
+	if err := s.r.Request(ctx, http.MethodPatch, path, &body, &resource); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
 

--- a/resources/service.go
+++ b/resources/service.go
@@ -47,6 +47,17 @@ func (s *Service) Update(ctx context.Context, id int64, req *UpdateRequest) (*Re
 
 func (s *Service) Delete(ctx context.Context, resourceID int64) error {
 	path := fmt.Sprintf("/cdn/resources/%d", resourceID)
+
+	var deactivateRequestBody ActivateRequest = ActivateRequest{
+		Active: false,
+	}
+	var resource Resource
+
+	// deactivate the resource instance before deletion
+	if err := s.r.Request(ctx, http.MethodPatch, path, &deactivateRequestBody, &resource); err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+
 	if err := s.r.Request(ctx, http.MethodDelete, path, nil, nil); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -35,6 +35,10 @@ type UpdateRequest struct {
 	Options                *gcore.Options `json:"options,omitempty"`
 }
 
+type ActivateRequest struct {
+	Active bool `json:"active"`
+}
+
 type Rule struct {
 	ID                     int64          `json:"id"`
 	Name                   string         `json:"name"`

--- a/rules/service.go
+++ b/rules/service.go
@@ -53,6 +53,17 @@ func (s *Service) Update(ctx context.Context, resourceID, ruleID int64, req *Upd
 
 func (s *Service) Delete(ctx context.Context, resourceID, ruleID int64) error {
 	path := fmt.Sprintf("/cdn/resources/%d/rules/%d", resourceID, ruleID)
+
+	var deactivateRequestBody ActivateRequest = ActivateRequest{
+		Active: false,
+	}
+	var rule Rule
+
+	// deactivate the rule instance before deletion
+	if err := s.r.Request(ctx, http.MethodPatch, path, &deactivateRequestBody, &rule); err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+
 	if err := s.r.Request(ctx, http.MethodDelete, path, nil, nil); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}

--- a/rules/service.go
+++ b/rules/service.go
@@ -54,13 +54,13 @@ func (s *Service) Update(ctx context.Context, resourceID, ruleID int64, req *Upd
 func (s *Service) Delete(ctx context.Context, resourceID, ruleID int64) error {
 	path := fmt.Sprintf("/cdn/resources/%d/rules/%d", resourceID, ruleID)
 
-	var deactivateRequestBody ActivateRequest = ActivateRequest{
+	var body ActivateRequest = ActivateRequest{
 		Active: false,
 	}
 	var rule Rule
 
 	// deactivate the rule instance before deletion
-	if err := s.r.Request(ctx, http.MethodPatch, path, &deactivateRequestBody, &rule); err != nil {
+	if err := s.r.Request(ctx, http.MethodPatch, path, &body, &rule); err != nil {
 		return fmt.Errorf("request: %w", err)
 	}
 


### PR DESCRIPTION
- respect the 2-step deletion logic for CDN resources and rules
- add a deactivation request before instance deletion